### PR TITLE
Changed the key to show the ui from END to F10 for people who dont have END

### DIFF
--- a/FaucetExec/src/overlay/overlay.cpp
+++ b/FaucetExec/src/overlay/overlay.cpp
@@ -204,7 +204,7 @@ void gui::overlay::render()
 		move_window(hw);
 
 		if (check == true) {
-			if ((GetAsyncKeyState(VK_END) & 1))
+			if ((GetAsyncKeyState(VK_F10) & 1))
 				draw = !draw;
 			check = !check;
 		}

--- a/FaucetExec/src/overlay/overlay.cpp
+++ b/FaucetExec/src/overlay/overlay.cpp
@@ -183,7 +183,7 @@ void gui::overlay::render()
 
 	editor.SetLanguageDefinition(TextEditor::LanguageDefinition::Lua());
 
-	editor.SetText(R"(print('gex on top! (Made by now and http2'))");
+	editor.SetText(R"(print('GEX on top! (Made by now and http2)'))"); // swapped from whover fucking retard put "editor.SetText(R"(print('gex on top! (Made by now and http2'))");" a tiny mistake I picked up on hehe
 
 	while (!done)
 	{


### PR DESCRIPTION
NOW is fit
#1 
EDIT:
@now420 if u push the commit in entry.cpp i forgot to change `std::cout << "hit END on ur keyboard to toggle ui" << std::endl;` to `std::cout << "hit F10 on ur keyboard to toggle ui" << std::endl;` so if u push the commit pleas change entry.cpp
